### PR TITLE
chore(vercel): limit automatic branch deployments

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "git": {
+    "deploymentEnabled": {
+      "*": false,
+      "main": true,
+      "preview": true
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Restrict automatic Vercel deployments to the `main` and `preview` branches so feature and Dependabot branches do not consume deployment-triggered GitHub Actions minutes.

## Changes

* Add `vercel.json` with a Git deployment allowlist.
* Disable automatic deployments for all branches by default.
* Explicitly allow `main` and `preview`.

## Testing

* Validated the configuration against Vercel's official `git.deploymentEnabled` schema.

## Notes

The project-level ignored-build gate is also configured in Vercel as an immediate fallback.