### PR TITLE
ci(dependabot): add dependabot.yml with grouped minor/patch updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,30 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+      timezone: "America/Sao_Paulo"
+    open-pull-requests-limit: 10
+    groups:
+      minor-and-patch:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+      timezone: "America/Sao_Paulo"
+    open-pull-requests-limit: 5
+    groups:
+      github-actions:
+        patterns:
+          - "*"


### PR DESCRIPTION
Repo tinha zero `dependabot.yml` — as atualizações vinham só do GitHub Security Updates (hoje pausado, provavelmente autothrottled depois de falhas repetidas na PR do Next 14→15). Adiciona agrupamento semanal de minor/patch pra npm e github-actions, mesmo padrão aplicado hoje em RASport e guinchonahora.

Não mexe nas 6 PRs paradas desde fev-abr/2026 — isso ainda precisa de decisão manual.

🤖 Gerado com [Claude Code](https://claude.com/claude-code)